### PR TITLE
chore(Safehouse/Misc) Add safehouse list to player

### DIFF
--- a/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISSafeTogetherhousesList.lua
+++ b/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISSafeTogetherhousesList.lua
@@ -1,0 +1,127 @@
+ISSafeTogetherhousesList = ISPanel:derive("ISSafeTogetherhousesList")
+ISSafeTogetherhousesList.messages = {}
+
+local FONT_HGT_SMALL = getTextManager():getFontHeight(UIFont.Small)
+local FONT_HGT_MEDIUM = getTextManager():getFontHeight(UIFont.Medium)
+
+function ISSafeTogetherhousesList:initialise()
+    ISPanel.initialise(self)
+    local btnWid = 100
+    local btnHgt = math.max(25, FONT_HGT_SMALL + 3 * 2)
+    local padBottom = 10
+
+    self.no = ISButton:new(10, self:getHeight() - padBottom - btnHgt, btnWid, btnHgt, getText("IGUI_CraftUI_Close"), self, ISSafeTogetherhousesList.onClick)
+    self.no.internal = "CANCEL"
+    self.no.anchorTop = false
+    self.no.anchorBottom = true
+    self.no:initialise()
+    self.no:instantiate()
+    self.no.borderColor = {r=1, g=1, b=1, a=0.1}
+    self:addChild(self.no)
+
+    local listY = 20 + FONT_HGT_MEDIUM + 20
+    self.datas = ISScrollingListBox:new(10, listY, self.width - 20, self.height - padBottom - btnHgt - padBottom - listY)
+    self.datas:initialise()
+    self.datas:instantiate()
+    self.datas.itemheight = FONT_HGT_SMALL + 2 * 2
+    self.datas.selected = 0
+    self.datas.joypadParent = self
+    self.datas.font = UIFont.NewSmall
+    self.datas.doDrawItem = self.drawDatas
+    self.datas.drawBorder = true
+    self:addChild(self.datas)
+
+    self.viewBtn = ISButton:new(self.no.x + 150,  self:getHeight() - padBottom - btnHgt, btnWid, btnHgt, getText("IGUI_PlayerStats_View"), self, ISSafeTogetherhousesList.onClick)
+    self.viewBtn.internal = "VIEW"
+    self.viewBtn.anchorTop = false
+    self.viewBtn.anchorBottom = true
+    self.viewBtn:initialise()
+    self.viewBtn:instantiate()
+    self.viewBtn.borderColor = {r=1, g=1, b=1, a=0.1}
+    self:addChild(self.viewBtn)
+    self.viewBtn.enable = false
+
+    self:populateList()
+
+end
+
+function ISSafeTogetherhousesList:populateList()
+    self.datas:clear()
+    for i=0, SafeHouse.getSafehouseList():size() - 1 do
+        local safe = SafeHouse.getSafehouseList():get(i)
+        if ((safe:getOwner() == self.player) or (safe:playerAllowed(self.player:getUsername()))) then
+            self.datas:addItem(safe:getTitle(), safe)
+        end
+    end
+end
+
+function ISSafeTogetherhousesList:drawDatas(y, item, alt)
+    local a = 0.9
+
+    self:drawRectBorder(0, (y), self:getWidth(), self.itemheight - 1, a, self.borderColor.r, self.borderColor.g, self.borderColor.b)
+
+    if self.selected == item.index then
+        self:drawRect(0, (y), self:getWidth(), self.itemheight - 1, 0.3, 0.7, 0.35, 0.15)
+        self.parent.viewBtn.enable = true
+        self.parent.selectedSafehouse = item.item
+    end
+
+    self:drawText(item.item:getTitle() .. " - " .. getText("IGUI_FactionUI_FactionsListPlayers", item.item:getPlayers():size(), item.item:getOwner()), 10, y + 2, 1, 1, 1, a, self.font)
+
+    return y + self.itemheight
+end
+
+function ISSafeTogetherhousesList:prerender()
+    local z = 20
+    local splitPoint = 100
+    local x = 10
+    self:drawRect(0, 0, self.width, self.height, self.backgroundColor.a, self.backgroundColor.r, self.backgroundColor.g, self.backgroundColor.b)
+    self:drawRectBorder(0, 0, self.width, self.height, self.borderColor.a, self.borderColor.r, self.borderColor.g, self.borderColor.b)
+    self:drawText(getText("IGUI_AdminPanel_SeeSafehouses"), self.width/2 - (getTextManager():MeasureStringX(UIFont.Medium, getText("IGUI_AdminPanel_SeeSafehouses")) / 2), z, 1,1,1,1, UIFont.Medium)
+    z = z + 30
+end
+
+function ISSafeTogetherhousesList:onClick(button)
+    if button.internal == "CANCEL" then
+        self:close()
+    end
+    if button.internal == "VIEW" then
+        local safehouseUI = ISSafehouseUI:new(getCore():getScreenWidth() / 2 - 250,getCore():getScreenHeight() / 2 - 225, 500, 450, self.selectedSafehouse, self.player)
+        safehouseUI:initialise()
+        safehouseUI:addToUIManager()
+        self:close()
+    end
+end
+
+function ISSafeTogetherhousesList:close()
+    self:setVisible(false)
+    self:removeFromUIManager()
+    ISSafeTogetherhousesList.instance = nil
+end
+
+function ISSafeTogetherhousesList:new(x, y, width, height, player)
+    local o = {}
+    x = getCore():getScreenWidth() / 2 - (width / 2)
+    y = getCore():getScreenHeight() / 2 - (height / 2)
+    o = ISPanel:new(x, y, width, height)
+    setmetatable(o, self)
+    self.__index = self
+
+    o.borderColor = {r=0.4, g=0.4, b=0.4, a=1}
+    o.backgroundColor = {r=0, g=0, b=0, a=0.8}
+    o.width = width
+    o.height = height
+    o.player = player
+    o.selectedFaction = nil
+    o.moveWithMouse = true
+    ISSafeTogetherhousesList.instance = o
+    return o
+end
+
+function ISSafeTogetherhousesList.OnSafehousesChanged()
+    if ISSafeTogetherhousesList.instance then
+        ISSafeTogetherhousesList.instance:populateList()
+    end
+end
+
+Events.OnSafehousesChanged.Add(ISSafeTogetherhousesList.OnSafehousesChanged)

--- a/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISSafeTogetherhousesList.lua
+++ b/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISSafeTogetherhousesList.lua
@@ -66,7 +66,10 @@ function ISSafeTogetherhousesList:drawDatas(y, item, alt)
         self.parent.selectedSafehouse = item.item
     end
 
-    self:drawText(item.item:getTitle() .. " - " .. getText("IGUI_FactionUI_FactionsListPlayers", item.item:getPlayers():size(), item.item:getOwner()), 10, y + 2, 1, 1, 1, a, self.font)
+    local playersInSafehouse = item.item:getPlayers():size()
+    if playersInSafehouse == 0 then playersInSafehouse = playersInSafehouse + 1 end
+
+    self:drawText(item.item:getTitle() .. " - " .. getText("IGUI_FactionUI_FactionsListPlayers", playersInSafehouse, item.item:getOwner()), 10, y + 2, 1, 1, 1, a, self.font)
 
     return y + self.itemheight
 end

--- a/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISUserPanelUI.lua
+++ b/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISUserPanelUI.lua
@@ -1,0 +1,231 @@
+--
+-- Created by IntelliJ IDEA.
+-- User: RJ
+-- Date: 21/09/16
+-- Time: 10:19
+-- To change this template use File | Settings | File Templates.
+--
+
+--***********************************************************
+--**                    ROBERT JOHNSON                     **
+--***********************************************************
+
+require "ISUI/ISPanel"
+
+ISUserPanelUI = ISPanel:derive("ISUserPanelUI");
+
+local FONT_HGT_SMALL = getTextManager():getFontHeight(UIFont.Small)
+local FONT_HGT_MEDIUM = getTextManager():getFontHeight(UIFont.Medium)
+local FONT_HGT_LARGE = getTextManager():getFontHeight(UIFont.Large)
+
+--************************************************************************--
+--** ISPanel:initialise
+--**
+--************************************************************************--
+
+function ISUserPanelUI:initialise()
+    ISPanel.initialise(self);
+    self:create();
+end
+
+
+function ISUserPanelUI:setVisible(visible)
+    --    self.parent:setVisible(visible);
+    self.javaObject:setVisible(visible);
+end
+
+function ISUserPanelUI:render()
+    local z = 20;
+
+    self:drawText(getText("UI_mainscreen_userpanel"), self.width/2 - (getTextManager():MeasureStringX(UIFont.Medium, getText("UI_mainscreen_userpanel")) / 2), z, 1,1,1,1, UIFont.Medium);
+    z = z + 30;
+
+    self:updateButtons();
+
+end
+
+function ISUserPanelUI:create()
+    local btnWid = 150
+    local btnHgt = math.max(25, FONT_HGT_SMALL + 3 * 2)
+    local padBottom = 10
+
+    local y = 70;
+
+    self.factionBtn = ISButton:new(10, y, btnWid, btnHgt, getText("UI_userpanel_factionpanel"), self, ISUserPanelUI.onOptionMouseDown);
+    self.factionBtn.internal = "FACTIONPANEL";
+    self.factionBtn:initialise();
+    self.factionBtn:instantiate();
+    self.factionBtn.borderColor = self.buttonBorderColor;
+    self:addChild(self.factionBtn);
+    y = y + btnHgt + 5;
+
+    if SafeHouse.hasSafehouse(self.player) then
+        self.safehouseBtn = ISButton:new(10, y, btnWid, btnHgt, getText("IGUI_SafehouseUI_Safehouse"), self, ISUserPanelUI.onOptionMouseDown);
+        self.safehouseBtn.internal = "SAFEHOUSEPANEL";
+        self.safehouseBtn:initialise();
+        self.safehouseBtn:instantiate();
+        self.safehouseBtn.borderColor = self.buttonBorderColor;
+        self:addChild(self.safehouseBtn);
+        y = y + btnHgt + 5;
+    end
+
+    self.ticketsBtn = ISButton:new(10, y, btnWid, btnHgt, getText("UI_userpanel_tickets"), self, ISUserPanelUI.onOptionMouseDown);
+    self.ticketsBtn.internal = "TICKETS";
+    self.ticketsBtn:initialise();
+    self.ticketsBtn:instantiate();
+    self.ticketsBtn.borderColor = self.buttonBorderColor;
+    self:addChild(self.ticketsBtn);
+    y = y + btnHgt + 5;
+
+    if not Faction.isAlreadyInFaction(self.player) then
+        self.factionBtn.title = getText("IGUI_FactionUI_CreateFaction");
+        if not Faction.canCreateFaction(self.player) then
+            self.factionBtn.enable = false;
+            self.factionBtn.tooltip = getText("IGUI_FactionUI_FactionSurvivalDay", getServerOptions():getInteger("FactionDaySurvivedToCreate"));
+        end
+        self.factionBtn:setWidthToTitle(self.factionBtn.width)
+    end
+    
+    self.serverOptionBtn = ISButton:new(10, y, btnWid, btnHgt, getText("IGUI_AdminPanel_SeeServerOptions"), self, ISUserPanelUI.onOptionMouseDown);
+    self.serverOptionBtn.internal = "SERVEROPTIONS";
+    self.serverOptionBtn:initialise();
+    self.serverOptionBtn:instantiate();
+    self.serverOptionBtn.borderColor = self.buttonBorderColor;
+    self:addChild(self.serverOptionBtn);
+    y = y + btnHgt + 5;
+
+    y = 70;
+
+    self.showConnectionInfo = ISTickBox:new(10 + btnWid + 20, y, btnWid, btnHgt, getText("IGUI_UserPanel_ShowConnectionInfo"), self, ISUserPanelUI.onShowConnectionInfo);
+    self.showConnectionInfo:initialise();
+    self.showConnectionInfo:instantiate();
+    self.showConnectionInfo.selected[1] = isShowConnectionInfo();
+    self.showConnectionInfo:addOption(getText("IGUI_UserPanel_ShowConnectionInfo"));
+    self:addChild(self.showConnectionInfo);
+    y = y + btnHgt + 5;
+
+    self.showServerInfo = ISTickBox:new(10 + btnWid + 20, y, btnWid, btnHgt, getText("IGUI_UserPanel_ShowServerInfo"), self, ISUserPanelUI.onShowServerInfo);
+    self.showServerInfo:initialise();
+    self.showServerInfo:instantiate();
+    self.showServerInfo.selected[1] = isShowServerInfo();
+    self.showServerInfo:addOption(getText("IGUI_UserPanel_ShowServerInfo"));
+    self:addChild(self.showServerInfo);
+    y = y + btnHgt + 5;
+
+    self.showPingInfo = ISTickBox:new(10 + btnWid + 20, y, btnWid, btnHgt, getText("IGUI_UserPanel_ShowPingInfo"), self, ISUserPanelUI.onShowPingInfo);
+    self.showPingInfo:initialise();
+    self.showPingInfo:instantiate();
+    self.showPingInfo.selected[1] = isShowPingInfo();
+    self.showPingInfo:addOption(getText("IGUI_UserPanel_ShowPingInfo"));
+    self:addChild(self.showPingInfo);
+    y = y + btnHgt + 5;
+
+    local width = 0
+    for _,child in pairs(self:getChildren()) do
+        width = math.max(width, child:getWidth())
+    end
+    for _,child in pairs(self:getChildren()) do
+        child:setWidth(width)
+    end
+
+    self:setWidth(10 + width + 20 + width + 10)
+
+    self.cancel = ISButton:new((self:getWidth() / 2) + 5, self:getHeight() - padBottom - btnHgt, btnWid, btnHgt, getText("UI_btn_close"), self, ISUserPanelUI.onOptionMouseDown);
+    self.cancel.internal = "CANCEL";
+    self.cancel:initialise();
+    self.cancel:instantiate();
+    self.cancel.borderColor = self.buttonBorderColor;
+    self:addChild(self.cancel);
+end
+
+function ISUserPanelUI:onShowConnectionInfo(option, enabled)
+    setShowConnectionInfo(enabled);
+end
+
+function ISUserPanelUI:onShowServerInfo(option, enabled)
+    setShowServerInfo(enabled);
+end
+
+function ISUserPanelUI:onShowPingInfo(option, enabled)
+    setShowPingInfo(enabled);
+end
+
+function ISUserPanelUI:updateButtons()
+    if not Faction.isAlreadyInFaction(self.player) then
+        self.factionBtn.title = getText("IGUI_FactionUI_CreateFaction");
+        if not Faction.canCreateFaction(self.player) then
+            self.factionBtn.enable = false;
+            self.factionBtn.tooltip = getText("IGUI_FactionUI_FactionSurvivalDay", getServerOptions():getInteger("FactionDaySurvivedToCreate"));
+        end
+    else
+        self.factionBtn.title = getText("UI_userpanel_factionpanel");
+    end
+end
+
+function ISUserPanelUI:onOptionMouseDown(button, x, y)
+    if button.internal == "SAFEHOUSEPANEL" then
+        if SafeHouse.hasSafehouse(self.player) then
+            local modal = ISSafehouseUI:new(getCore():getScreenWidth() / 2 - 250, getCore():getScreenHeight() / 2 - 225, 500, 450, SafeHouse.hasSafehouse(self.player), self.player);
+            modal:initialise();
+            modal:addToUIManager();
+        end
+    end
+    if button.internal == "FACTIONPANEL" then
+        if ISFactionUI.instance then
+            ISFactionUI.instance:close()
+        end
+        if ISCreateFactionUI.instance then
+            ISCreateFactionUI.instance:close()
+        end
+        if Faction.isAlreadyInFaction(self.player) then
+            local modal = ISFactionUI:new(getCore():getScreenWidth() / 2 - 250, getCore():getScreenHeight() / 2 - 225, 500, 450, Faction.getPlayerFaction(self.player), self.player);
+            modal:initialise();
+            modal:addToUIManager();
+        else
+            local modal = ISCreateFactionUI:new(self.x + 100, self.y + 100, 350, 250, self.player)
+            modal:initialise();
+            modal:addToUIManager();
+        end
+    end
+    if button.internal == "TICKETS" then
+        if ISTicketsUI.instance then
+            ISTicketsUI.instance:close()
+        end
+        local modal = ISTicketsUI:new(getCore():getScreenWidth() / 2 - 250, getCore():getScreenHeight() / 2 - 225, 500, 450, self.player);
+        modal:initialise();
+        modal:addToUIManager();
+    end
+    if button.internal == "SERVEROPTIONS" then
+        if ISServerOptions.instance then
+            ISServerOptions.instance:close()
+        end
+        local ui = ISServerOptions:new(50,50,600,600, self.player)
+        ui:initialise();
+        ui:addToUIManager();
+    end
+    if button.internal == "CANCEL" then
+        self:close()
+    end
+end
+
+function ISUserPanelUI:close()
+    self:setVisible(false)
+    self:removeFromUIManager()
+    ISUserPanelUI.instance = nil;
+end
+
+function ISUserPanelUI:new(x, y, width, height, player)
+    local o = {};
+    o = ISPanel:new(x, y, width, height);
+    setmetatable(o, self);
+    self.__index = self;
+    self.player = player;
+    o.variableColor={r=0.9, g=0.55, b=0.1, a=1};
+    o.borderColor = {r=0.4, g=0.4, b=0.4, a=1};
+    o.backgroundColor = {r=0, g=0, b=0, a=0.8};
+    o.buttonBorderColor = {r=0.7, g=0.7, b=0.7, a=0.5};
+    o.zOffsetSmallFont = 25;
+    o.moveWithMouse = true;
+    ISUserPanelUI.instance = o
+    return o;
+end

--- a/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISUserPanelUI.lua
+++ b/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISUserPanelUI.lua
@@ -163,9 +163,12 @@ end
 function ISUserPanelUI:onOptionMouseDown(button, x, y)
     if button.internal == "SAFEHOUSEPANEL" then
         if SafeHouse.hasSafehouse(self.player) then
-            local modal = ISSafehouseUI:new(getCore():getScreenWidth() / 2 - 250, getCore():getScreenHeight() / 2 - 225, 500, 450, SafeHouse.hasSafehouse(self.player), self.player)
-            modal:initialise()
-            modal:addToUIManager()
+            if ISSafeTogetherhousesList.instance then
+                ISSafeTogetherhousesList.instance:close()
+            end
+            local ui = ISSafeTogetherhousesList:new(50,50,600,600, self.player)
+            ui:initialise()
+            ui:addToUIManager()
         end
     end
     if button.internal == "FACTIONPANEL" then

--- a/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISUserPanelUI.lua
+++ b/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISUserPanelUI.lua
@@ -12,35 +12,29 @@
 
 require "ISUI/ISPanel"
 
-ISUserPanelUI = ISPanel:derive("ISUserPanelUI");
+ISUserPanelUI = ISPanel:derive("ISUserPanelUI")
 
 local FONT_HGT_SMALL = getTextManager():getFontHeight(UIFont.Small)
 local FONT_HGT_MEDIUM = getTextManager():getFontHeight(UIFont.Medium)
 local FONT_HGT_LARGE = getTextManager():getFontHeight(UIFont.Large)
 
---************************************************************************--
---** ISPanel:initialise
---**
---************************************************************************--
-
 function ISUserPanelUI:initialise()
-    ISPanel.initialise(self);
-    self:create();
+    ISPanel.initialise(self)
+    self:create()
 end
 
 
 function ISUserPanelUI:setVisible(visible)
-    --    self.parent:setVisible(visible);
-    self.javaObject:setVisible(visible);
+    self.javaObject:setVisible(visible)
 end
 
 function ISUserPanelUI:render()
-    local z = 20;
+    local z = 20
 
-    self:drawText(getText("UI_mainscreen_userpanel"), self.width/2 - (getTextManager():MeasureStringX(UIFont.Medium, getText("UI_mainscreen_userpanel")) / 2), z, 1,1,1,1, UIFont.Medium);
-    z = z + 30;
+    self:drawText(getText("UI_mainscreen_userpanel"), self.width/2 - (getTextManager():MeasureStringX(UIFont.Medium, getText("UI_mainscreen_userpanel")) / 2), z, 1,1,1,1, UIFont.Medium)
+    z = z + 30
 
-    self:updateButtons();
+    self:updateButtons()
 
 end
 
@@ -49,76 +43,76 @@ function ISUserPanelUI:create()
     local btnHgt = math.max(25, FONT_HGT_SMALL + 3 * 2)
     local padBottom = 10
 
-    local y = 70;
+    local y = 70
 
-    self.factionBtn = ISButton:new(10, y, btnWid, btnHgt, getText("UI_userpanel_factionpanel"), self, ISUserPanelUI.onOptionMouseDown);
-    self.factionBtn.internal = "FACTIONPANEL";
-    self.factionBtn:initialise();
-    self.factionBtn:instantiate();
-    self.factionBtn.borderColor = self.buttonBorderColor;
-    self:addChild(self.factionBtn);
-    y = y + btnHgt + 5;
+    self.factionBtn = ISButton:new(10, y, btnWid, btnHgt, getText("UI_userpanel_factionpanel"), self, ISUserPanelUI.onOptionMouseDown)
+    self.factionBtn.internal = "FACTIONPANEL"
+    self.factionBtn:initialise()
+    self.factionBtn:instantiate()
+    self.factionBtn.borderColor = self.buttonBorderColor
+    self:addChild(self.factionBtn)
+    y = y + btnHgt + 5
 
     if SafeHouse.hasSafehouse(self.player) then
-        self.safehouseBtn = ISButton:new(10, y, btnWid, btnHgt, getText("IGUI_SafehouseUI_Safehouse"), self, ISUserPanelUI.onOptionMouseDown);
-        self.safehouseBtn.internal = "SAFEHOUSEPANEL";
-        self.safehouseBtn:initialise();
-        self.safehouseBtn:instantiate();
-        self.safehouseBtn.borderColor = self.buttonBorderColor;
-        self:addChild(self.safehouseBtn);
-        y = y + btnHgt + 5;
+        self.safehouseBtn = ISButton:new(10, y, btnWid, btnHgt, getText("IGUI_SafehouseUI_Safehouse"), self, ISUserPanelUI.onOptionMouseDown)
+        self.safehouseBtn.internal = "SAFEHOUSEPANEL"
+        self.safehouseBtn:initialise()
+        self.safehouseBtn:instantiate()
+        self.safehouseBtn.borderColor = self.buttonBorderColor
+        self:addChild(self.safehouseBtn)
+        y = y + btnHgt + 5
     end
 
-    self.ticketsBtn = ISButton:new(10, y, btnWid, btnHgt, getText("UI_userpanel_tickets"), self, ISUserPanelUI.onOptionMouseDown);
-    self.ticketsBtn.internal = "TICKETS";
-    self.ticketsBtn:initialise();
-    self.ticketsBtn:instantiate();
-    self.ticketsBtn.borderColor = self.buttonBorderColor;
-    self:addChild(self.ticketsBtn);
-    y = y + btnHgt + 5;
+    self.ticketsBtn = ISButton:new(10, y, btnWid, btnHgt, getText("UI_userpanel_tickets"), self, ISUserPanelUI.onOptionMouseDown)
+    self.ticketsBtn.internal = "TICKETS"
+    self.ticketsBtn:initialise()
+    self.ticketsBtn:instantiate()
+    self.ticketsBtn.borderColor = self.buttonBorderColor
+    self:addChild(self.ticketsBtn)
+    y = y + btnHgt + 5
 
     if not Faction.isAlreadyInFaction(self.player) then
-        self.factionBtn.title = getText("IGUI_FactionUI_CreateFaction");
+        self.factionBtn.title = getText("IGUI_FactionUI_CreateFaction")
         if not Faction.canCreateFaction(self.player) then
-            self.factionBtn.enable = false;
-            self.factionBtn.tooltip = getText("IGUI_FactionUI_FactionSurvivalDay", getServerOptions():getInteger("FactionDaySurvivedToCreate"));
+            self.factionBtn.enable = false
+            self.factionBtn.tooltip = getText("IGUI_FactionUI_FactionSurvivalDay", getServerOptions():getInteger("FactionDaySurvivedToCreate"))
         end
         self.factionBtn:setWidthToTitle(self.factionBtn.width)
     end
-    
-    self.serverOptionBtn = ISButton:new(10, y, btnWid, btnHgt, getText("IGUI_AdminPanel_SeeServerOptions"), self, ISUserPanelUI.onOptionMouseDown);
-    self.serverOptionBtn.internal = "SERVEROPTIONS";
-    self.serverOptionBtn:initialise();
-    self.serverOptionBtn:instantiate();
-    self.serverOptionBtn.borderColor = self.buttonBorderColor;
-    self:addChild(self.serverOptionBtn);
-    y = y + btnHgt + 5;
 
-    y = 70;
+    self.serverOptionBtn = ISButton:new(10, y, btnWid, btnHgt, getText("IGUI_AdminPanel_SeeServerOptions"), self, ISUserPanelUI.onOptionMouseDown)
+    self.serverOptionBtn.internal = "SERVEROPTIONS"
+    self.serverOptionBtn:initialise()
+    self.serverOptionBtn:instantiate()
+    self.serverOptionBtn.borderColor = self.buttonBorderColor
+    self:addChild(self.serverOptionBtn)
+    y = y + btnHgt + 5
 
-    self.showConnectionInfo = ISTickBox:new(10 + btnWid + 20, y, btnWid, btnHgt, getText("IGUI_UserPanel_ShowConnectionInfo"), self, ISUserPanelUI.onShowConnectionInfo);
-    self.showConnectionInfo:initialise();
-    self.showConnectionInfo:instantiate();
-    self.showConnectionInfo.selected[1] = isShowConnectionInfo();
-    self.showConnectionInfo:addOption(getText("IGUI_UserPanel_ShowConnectionInfo"));
-    self:addChild(self.showConnectionInfo);
-    y = y + btnHgt + 5;
+    y = 70
 
-    self.showServerInfo = ISTickBox:new(10 + btnWid + 20, y, btnWid, btnHgt, getText("IGUI_UserPanel_ShowServerInfo"), self, ISUserPanelUI.onShowServerInfo);
-    self.showServerInfo:initialise();
-    self.showServerInfo:instantiate();
-    self.showServerInfo.selected[1] = isShowServerInfo();
-    self.showServerInfo:addOption(getText("IGUI_UserPanel_ShowServerInfo"));
-    self:addChild(self.showServerInfo);
-    y = y + btnHgt + 5;
+    self.showConnectionInfo = ISTickBox:new(10 + btnWid + 20, y, btnWid, btnHgt, getText("IGUI_UserPanel_ShowConnectionInfo"), self, ISUserPanelUI.onShowConnectionInfo)
+    self.showConnectionInfo:initialise()
+    self.showConnectionInfo:instantiate()
+    self.showConnectionInfo.selected[1] = isShowConnectionInfo()
+    self.showConnectionInfo:addOption(getText("IGUI_UserPanel_ShowConnectionInfo"))
+    self:addChild(self.showConnectionInfo)
+    y = y + btnHgt + 5
 
-    self.showPingInfo = ISTickBox:new(10 + btnWid + 20, y, btnWid, btnHgt, getText("IGUI_UserPanel_ShowPingInfo"), self, ISUserPanelUI.onShowPingInfo);
-    self.showPingInfo:initialise();
-    self.showPingInfo:instantiate();
-    self.showPingInfo.selected[1] = isShowPingInfo();
-    self.showPingInfo:addOption(getText("IGUI_UserPanel_ShowPingInfo"));
-    self:addChild(self.showPingInfo);
-    y = y + btnHgt + 5;
+    self.showServerInfo = ISTickBox:new(10 + btnWid + 20, y, btnWid, btnHgt, getText("IGUI_UserPanel_ShowServerInfo"), self, ISUserPanelUI.onShowServerInfo)
+    self.showServerInfo:initialise()
+    self.showServerInfo:instantiate()
+    self.showServerInfo.selected[1] = isShowServerInfo()
+    self.showServerInfo:addOption(getText("IGUI_UserPanel_ShowServerInfo"))
+    self:addChild(self.showServerInfo)
+    y = y + btnHgt + 5
+
+    self.showPingInfo = ISTickBox:new(10 + btnWid + 20, y, btnWid, btnHgt, getText("IGUI_UserPanel_ShowPingInfo"), self, ISUserPanelUI.onShowPingInfo)
+    self.showPingInfo:initialise()
+    self.showPingInfo:instantiate()
+    self.showPingInfo.selected[1] = isShowPingInfo()
+    self.showPingInfo:addOption(getText("IGUI_UserPanel_ShowPingInfo"))
+    self:addChild(self.showPingInfo)
+    y = y + btnHgt + 5
 
     local width = 0
     for _,child in pairs(self:getChildren()) do
@@ -130,44 +124,44 @@ function ISUserPanelUI:create()
 
     self:setWidth(10 + width + 20 + width + 10)
 
-    self.cancel = ISButton:new((self:getWidth() / 2) + 5, self:getHeight() - padBottom - btnHgt, btnWid, btnHgt, getText("UI_btn_close"), self, ISUserPanelUI.onOptionMouseDown);
-    self.cancel.internal = "CANCEL";
-    self.cancel:initialise();
-    self.cancel:instantiate();
-    self.cancel.borderColor = self.buttonBorderColor;
-    self:addChild(self.cancel);
+    self.cancel = ISButton:new((self:getWidth() / 2) + 5, self:getHeight() - padBottom - btnHgt, btnWid, btnHgt, getText("UI_btn_close"), self, ISUserPanelUI.onOptionMouseDown)
+    self.cancel.internal = "CANCEL"
+    self.cancel:initialise()
+    self.cancel:instantiate()
+    self.cancel.borderColor = self.buttonBorderColor
+    self:addChild(self.cancel)
 end
 
 function ISUserPanelUI:onShowConnectionInfo(option, enabled)
-    setShowConnectionInfo(enabled);
+    setShowConnectionInfo(enabled)
 end
 
 function ISUserPanelUI:onShowServerInfo(option, enabled)
-    setShowServerInfo(enabled);
+    setShowServerInfo(enabled)
 end
 
 function ISUserPanelUI:onShowPingInfo(option, enabled)
-    setShowPingInfo(enabled);
+    setShowPingInfo(enabled)
 end
 
 function ISUserPanelUI:updateButtons()
     if not Faction.isAlreadyInFaction(self.player) then
-        self.factionBtn.title = getText("IGUI_FactionUI_CreateFaction");
+        self.factionBtn.title = getText("IGUI_FactionUI_CreateFaction")
         if not Faction.canCreateFaction(self.player) then
-            self.factionBtn.enable = false;
-            self.factionBtn.tooltip = getText("IGUI_FactionUI_FactionSurvivalDay", getServerOptions():getInteger("FactionDaySurvivedToCreate"));
+            self.factionBtn.enable = false
+            self.factionBtn.tooltip = getText("IGUI_FactionUI_FactionSurvivalDay", getServerOptions():getInteger("FactionDaySurvivedToCreate"))
         end
     else
-        self.factionBtn.title = getText("UI_userpanel_factionpanel");
+        self.factionBtn.title = getText("UI_userpanel_factionpanel")
     end
 end
 
 function ISUserPanelUI:onOptionMouseDown(button, x, y)
     if button.internal == "SAFEHOUSEPANEL" then
         if SafeHouse.hasSafehouse(self.player) then
-            local modal = ISSafehouseUI:new(getCore():getScreenWidth() / 2 - 250, getCore():getScreenHeight() / 2 - 225, 500, 450, SafeHouse.hasSafehouse(self.player), self.player);
-            modal:initialise();
-            modal:addToUIManager();
+            local modal = ISSafehouseUI:new(getCore():getScreenWidth() / 2 - 250, getCore():getScreenHeight() / 2 - 225, 500, 450, SafeHouse.hasSafehouse(self.player), self.player)
+            modal:initialise()
+            modal:addToUIManager()
         end
     end
     if button.internal == "FACTIONPANEL" then
@@ -178,30 +172,30 @@ function ISUserPanelUI:onOptionMouseDown(button, x, y)
             ISCreateFactionUI.instance:close()
         end
         if Faction.isAlreadyInFaction(self.player) then
-            local modal = ISFactionUI:new(getCore():getScreenWidth() / 2 - 250, getCore():getScreenHeight() / 2 - 225, 500, 450, Faction.getPlayerFaction(self.player), self.player);
-            modal:initialise();
-            modal:addToUIManager();
+            local modal = ISFactionUI:new(getCore():getScreenWidth() / 2 - 250, getCore():getScreenHeight() / 2 - 225, 500, 450, Faction.getPlayerFaction(self.player), self.player)
+            modal:initialise()
+            modal:addToUIManager()
         else
             local modal = ISCreateFactionUI:new(self.x + 100, self.y + 100, 350, 250, self.player)
-            modal:initialise();
-            modal:addToUIManager();
+            modal:initialise()
+            modal:addToUIManager()
         end
     end
     if button.internal == "TICKETS" then
         if ISTicketsUI.instance then
             ISTicketsUI.instance:close()
         end
-        local modal = ISTicketsUI:new(getCore():getScreenWidth() / 2 - 250, getCore():getScreenHeight() / 2 - 225, 500, 450, self.player);
-        modal:initialise();
-        modal:addToUIManager();
+        local modal = ISTicketsUI:new(getCore():getScreenWidth() / 2 - 250, getCore():getScreenHeight() / 2 - 225, 500, 450, self.player)
+        modal:initialise()
+        modal:addToUIManager()
     end
     if button.internal == "SERVEROPTIONS" then
         if ISServerOptions.instance then
             ISServerOptions.instance:close()
         end
         local ui = ISServerOptions:new(50,50,600,600, self.player)
-        ui:initialise();
-        ui:addToUIManager();
+        ui:initialise()
+        ui:addToUIManager()
     end
     if button.internal == "CANCEL" then
         self:close()
@@ -211,21 +205,21 @@ end
 function ISUserPanelUI:close()
     self:setVisible(false)
     self:removeFromUIManager()
-    ISUserPanelUI.instance = nil;
+    ISUserPanelUI.instance = nil
 end
 
 function ISUserPanelUI:new(x, y, width, height, player)
-    local o = {};
-    o = ISPanel:new(x, y, width, height);
-    setmetatable(o, self);
-    self.__index = self;
-    self.player = player;
-    o.variableColor={r=0.9, g=0.55, b=0.1, a=1};
-    o.borderColor = {r=0.4, g=0.4, b=0.4, a=1};
-    o.backgroundColor = {r=0, g=0, b=0, a=0.8};
-    o.buttonBorderColor = {r=0.7, g=0.7, b=0.7, a=0.5};
-    o.zOffsetSmallFont = 25;
-    o.moveWithMouse = true;
+    local o = {}
+    o = ISPanel:new(x, y, width, height)
+    setmetatable(o, self)
+    self.__index = self
+    self.player = player
+    o.variableColor={r=0.9, g=0.55, b=0.1, a=1}
+    o.borderColor = {r=0.4, g=0.4, b=0.4, a=1}
+    o.backgroundColor = {r=0, g=0, b=0, a=0.8}
+    o.buttonBorderColor = {r=0.7, g=0.7, b=0.7, a=0.5}
+    o.zOffsetSmallFont = 25
+    o.moveWithMouse = true
     ISUserPanelUI.instance = o
-    return o;
+    return o
 end

--- a/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISUserPanelUI.lua
+++ b/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISUserPanelUI.lua
@@ -122,7 +122,7 @@ function ISUserPanelUI:create()
         child:setWidth(width)
     end
 
-    self:setWidth(10 + width + 20 + width + 10)
+    self:setWidth(10 + width + 20 + width + 10 + 50)
 
     self.cancel = ISButton:new((self:getWidth() / 2) + 5, self:getHeight() - padBottom - btnHgt, btnWid, btnHgt, getText("UI_btn_close"), self, ISUserPanelUI.onOptionMouseDown)
     self.cancel.internal = "CANCEL"

--- a/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISUserPanelUI.lua
+++ b/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISUserPanelUI.lua
@@ -63,13 +63,15 @@ function ISUserPanelUI:create()
         y = y + btnHgt + 5
     end
 
-    self.ticketsBtn = ISButton:new(10, y, btnWid, btnHgt, getText("UI_userpanel_tickets"), self, ISUserPanelUI.onOptionMouseDown)
-    self.ticketsBtn.internal = "TICKETS"
-    self.ticketsBtn:initialise()
-    self.ticketsBtn:instantiate()
-    self.ticketsBtn.borderColor = self.buttonBorderColor
-    self:addChild(self.ticketsBtn)
-    y = y + btnHgt + 5
+    if (self.player:getAccessLevel() == "Admin" or self.player:getAccessLevel() == "Moderator") then
+        self.ticketsBtn = ISButton:new(10, y, btnWid, btnHgt, getText("UI_userpanel_tickets"), self, ISUserPanelUI.onOptionMouseDown)
+        self.ticketsBtn.internal = "TICKETS"
+        self.ticketsBtn:initialise()
+        self.ticketsBtn:instantiate()
+        self.ticketsBtn.borderColor = self.buttonBorderColor
+        self:addChild(self.ticketsBtn)
+        y = y + btnHgt + 5
+    end
 
     if not Faction.isAlreadyInFaction(self.player) then
         self.factionBtn.title = getText("IGUI_FactionUI_CreateFaction")
@@ -80,13 +82,15 @@ function ISUserPanelUI:create()
         self.factionBtn:setWidthToTitle(self.factionBtn.width)
     end
 
-    self.serverOptionBtn = ISButton:new(10, y, btnWid, btnHgt, getText("IGUI_AdminPanel_SeeServerOptions"), self, ISUserPanelUI.onOptionMouseDown)
-    self.serverOptionBtn.internal = "SERVEROPTIONS"
-    self.serverOptionBtn:initialise()
-    self.serverOptionBtn:instantiate()
-    self.serverOptionBtn.borderColor = self.buttonBorderColor
-    self:addChild(self.serverOptionBtn)
-    y = y + btnHgt + 5
+    if (self.player:getAccessLevel() == "Admin" or self.player:getAccessLevel() == "Moderator") then
+        self.serverOptionBtn = ISButton:new(10, y, btnWid, btnHgt, getText("IGUI_AdminPanel_SeeServerOptions"), self, ISUserPanelUI.onOptionMouseDown)
+        self.serverOptionBtn.internal = "SERVEROPTIONS"
+        self.serverOptionBtn:initialise()
+        self.serverOptionBtn:instantiate()
+        self.serverOptionBtn.borderColor = self.buttonBorderColor
+        self:addChild(self.serverOptionBtn)
+        y = y + btnHgt + 5
+    end
 
     y = 70
 


### PR DESCRIPTION
- The shelter menu option has been replaced so that instead of showing a single shelter, it now displays a list of the shelters the player owns or has been invited to. This allows players to remotely access them to invite friends, remove people, or perform any other actions they previously had to perform from the shelter itself.
- In the user menu, some options are modified and disabled, such as viewing server options and tickets, which I don't really use. Later, I'll add options so each server can choose whether or not to use them. I don't use them.