### PR TITLE
chore(Safehouse/Misc) Prevent them from seeing many safehouses

### DIFF
--- a/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISSafeTogetherhousesList.lua
+++ b/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISSafeTogetherhousesList.lua
@@ -62,14 +62,20 @@ function ISSafeTogetherhousesList:drawDatas(y, item, alt)
 
     if self.selected == item.index then
         self:drawRect(0, (y), self:getWidth(), self.itemheight - 1, 0.3, 0.7, 0.35, 0.15)
-        self.parent.viewBtn.enable = true
+        if not ISSafehouseUI.instance then
+            self.parent.viewBtn.enable = true
+        else
+            self.parent.viewBtn.tooltip = "Solo puedes ver 1 refugio por vez"
+        end
         self.parent.selectedSafehouse = item.item
     end
 
     local playersInSafehouse = item.item:getPlayers():size()
+    local respawnInSafehouseActive = ""
     if playersInSafehouse == 0 then playersInSafehouse = playersInSafehouse + 1 end
+    if item.item:isRespawnInSafehouse(getPlayer():getUsername()) then respawnInSafehouseActive = getText("IGUI_SafehouseTogether_Respawn") else respawnInSafehouseActive = "" end
 
-    self:drawText(item.item:getTitle() .. " - " .. getText("IGUI_FactionUI_FactionsListPlayers", playersInSafehouse, item.item:getOwner()), 10, y + 2, 1, 1, 1, a, self.font)
+    self:drawText((string.format(getText("IGUI_SafehouseTogether_Safehouse"), item.item:getTitle(), item.item:getOwner(), playersInSafehouse, respawnInSafehouseActive)), 10, y + 2, 1, 1, 1, a, self.font)
 
     return y + self.itemheight
 end
@@ -80,7 +86,7 @@ function ISSafeTogetherhousesList:prerender()
     local x = 10
     self:drawRect(0, 0, self.width, self.height, self.backgroundColor.a, self.backgroundColor.r, self.backgroundColor.g, self.backgroundColor.b)
     self:drawRectBorder(0, 0, self.width, self.height, self.borderColor.a, self.borderColor.r, self.borderColor.g, self.borderColor.b)
-    self:drawText(getText("IGUI_AdminPanel_SeeSafehouses"), self.width/2 - (getTextManager():MeasureStringX(UIFont.Medium, getText("IGUI_AdminPanel_SeeSafehouses")) / 2), z, 1,1,1,1, UIFont.Medium)
+    self:drawText(string.format(getText("IGUI_SafehouseTogether_Safehouse_Owner"), self.player:getUsername()), self.width/2 - (getTextManager():MeasureStringX(UIFont.Medium, string.format(getText("IGUI_SafehouseTogether_Safehouse_Owner"), self.player:getUsername())) / 2), z, 1,1,1,1, UIFont.Medium)
     z = z + 30
 end
 
@@ -89,10 +95,12 @@ function ISSafeTogetherhousesList:onClick(button)
         self:close()
     end
     if button.internal == "VIEW" then
-        local safehouseUI = ISSafehouseUI:new(getCore():getScreenWidth() / 2 - 250,getCore():getScreenHeight() / 2 - 225, 500, 450, self.selectedSafehouse, self.player)
-        safehouseUI:initialise()
-        safehouseUI:addToUIManager()
-        self:close()
+        if not ISSafehouseUI.instance then
+            local safehouseUI = ISSafehouseUI:new(getCore():getScreenWidth() / 2 - 250,getCore():getScreenHeight() / 2 - 225, 500, 450, self.selectedSafehouse, self.player)
+            safehouseUI:initialise()
+            safehouseUI:addToUIManager()
+            self:close()
+        end
     end
 end
 

--- a/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISSafehouseUI.lua
+++ b/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISSafehouseUI.lua
@@ -154,6 +154,15 @@ function ISSafehouseUI:initialise()
 end
 
 function ISSafehouseUI:onClickRespawn(clickedOption, enabled)
+
+    for i=0, SafeHouse.getSafehouseList():size() - 1 do
+        local safe = SafeHouse.getSafehouseList():get(i)
+        if ((safe:getOwner() == self.player) or (safe:playerAllowed(self.player:getUsername()))) then
+            if (safe:isRespawnInSafehouse(self.player:getUsername())) then
+                safe:setRespawnInSafehouse(false, self.player:getUsername())
+            end
+        end
+    end
     self.safehouse:setRespawnInSafehouse(enabled, self.player:getUsername())
 end
 

--- a/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISSafehouseUI.lua
+++ b/Contents/mods/safetogether/media/lua/client/ISUI/UserPanel/ISSafehouseUI.lua
@@ -142,7 +142,15 @@ function ISSafehouseUI:initialise()
     self:addChild(self.respawn)
     self.respawn.safehouseUI = self
     if not getServerOptions():getBoolean("SafehouseAllowRespawn") then
-        self.respawn.enable = false
+        for i=0, SafeHouse.getSafehouseList():size() - 1 do
+            local safe = SafeHouse.getSafehouseList():get(i)
+            if ((safe:getOwner() == self.player) or (safe:playerAllowed(self.player:getUsername()))) then
+                if (safe:isRespawnInSafehouse(self.player:getUsername())) then
+                    safe:setRespawnInSafehouse(false, self.player:getUsername())
+                end
+            end
+        end
+        self.respawn:disableOption(getText("IGUI_SafehouseUI_Respawn"), true)
     end
 
     self.no:setY(self.respawn:getBottom() + 20)

--- a/Contents/mods/safetogether/media/lua/shared/Translate/AR/IG_UI_AR.txt
+++ b/Contents/mods/safetogether/media/lua/shared/Translate/AR/IG_UI_AR.txt
@@ -2,4 +2,7 @@ IG_UI_AR = {
     IGUI_SafehouseTogether_AlreadyInvited = "El jugador ya se encuentra dentro del refugio.",
     IGUI_notCanClaimLand = "Ya perteneces un refugio. Para poder reclamar uno. Primero debes abandonar el actual.",
     IGUI_haveExceededTheLimit = "Superaste el limite de safehouse a tu nombre que podes tener.",
+    IGUI_SafehouseTogether_Safehouse = "%s - Dueño: %s - Miembros: %d %s",
+    IGUI_SafehouseTogether_Safehouse_Owner = "Refugios de: %s",
+    IGUI_SafehouseTogether_Respawn = "- (Revivir acá)",
 }

--- a/Contents/mods/safetogether/media/lua/shared/Translate/EN/IG_UI_EN.txt
+++ b/Contents/mods/safetogether/media/lua/shared/Translate/EN/IG_UI_EN.txt
@@ -2,4 +2,7 @@ IG_UI_EN = {
     IGUI_SafehouseTogether_AlreadyInvited = "The player is already inside the safe house.",
     IGUI_notCanClaimLand = "You already belong to a safehouse. To claim one, you must first leave your current one.",
     IGUI_haveExceededTheLimit = "You have exceeded the limit of safehouses you can have in your name.",
+    IGUI_SafehouseTogether_Safehouse = "%s - Owner: %s - Members: %d %s",
+    IGUI_SafehouseTogether_Safehouse_Owner = "Safe houses of: %s",
+    IGUI_SafehouseTogether_Respawn = "- (Respawn)",
 }

--- a/Contents/mods/safetogether/media/lua/shared/Translate/ES/IG_UI_ES.txt
+++ b/Contents/mods/safetogether/media/lua/shared/Translate/ES/IG_UI_ES.txt
@@ -4,5 +4,5 @@ IG_UI_ES = {
     IGUI_haveExceededTheLimit = "Superaste el limite de safehouse a tu nombre que podes tener.",
     IGUI_SafehouseTogether_Safehouse = "%s - Dueño: %s - Miembros: %d %s",
     IGUI_SafehouseTogether_Safehouse_Owner = "Refugios de: %s",
-    IGUI_SafehouseTogether_Respawn = "- (Respawn)",
+    IGUI_SafehouseTogether_Respawn = "- (Revivir acá)",
 }

--- a/Contents/mods/safetogether/media/lua/shared/Translate/ES/IG_UI_ES.txt
+++ b/Contents/mods/safetogether/media/lua/shared/Translate/ES/IG_UI_ES.txt
@@ -2,4 +2,7 @@ IG_UI_ES = {
     IGUI_SafehouseTogether_AlreadyInvited = "El jugador ya se encuentra dentro del refugio.",
     IGUI_notCanClaimLand = "Ya perteneces un refugio. Para poder reclamar uno. Primero debes abandonar el actual.",
     IGUI_haveExceededTheLimit = "Superaste el limite de safehouse a tu nombre que podes tener.",
+    IGUI_SafehouseTogether_Safehouse = "%s - Dueño: %s - Miembros: %d %s",
+    IGUI_SafehouseTogether_Safehouse_Owner = "Refugios de: %s",
+    IGUI_SafehouseTogether_Respawn = "- (Respawn)",
 }


### PR DESCRIPTION
- If the player clicks respawn at the shelter, all other spawns will be removed, and the one the player selected will be added.
- If the option is disabled, we go through the list of shelters, remove the option, and disable the button so it can be clicked.
- Only one shelter is allowed to be viewed at a time.
- A tooltip is added, which we have to translate
- The text of the safe house menu is customized
- The message from the shelters is personalized
- If there is a spawn, the player is informed.
- The Spanish text is added (AR and ES)
- The English text is added (EN)